### PR TITLE
Fix bug in upload_iaintersect_result

### DIFF
--- a/biowardrobe_airflow_analysis/biowardrobe/db_uploader.py
+++ b/biowardrobe_airflow_analysis/biowardrobe/db_uploader.py
@@ -112,9 +112,9 @@ def upload_iaintersect_result(self, uid, filename):
                 continue
             line_splitted = [None if item == "NULL" else item for item in line.split()]
 
-            if len(line_splitted[0]) > 499:
+            if line_splitted[0] and len(line_splitted[0]) > 499:
                 line_splitted[0] = line_splitted[0][:450]
-            if len(line_splitted[1]) > 499:
+            if line_splitted[1] && len(line_splitted[1]) > 499:
                 line_splitted[1] = line_splitted[1][:450]
 
             self.cursor.execute(SQL + " (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)", tuple(line_splitted))

--- a/biowardrobe_airflow_analysis/biowardrobe/db_uploader.py
+++ b/biowardrobe_airflow_analysis/biowardrobe/db_uploader.py
@@ -114,7 +114,7 @@ def upload_iaintersect_result(self, uid, filename):
 
             if line_splitted[0] and len(line_splitted[0]) > 499:
                 line_splitted[0] = line_splitted[0][:450]
-            if line_splitted[1] && len(line_splitted[1]) > 499:
+            if line_splitted[1] and len(line_splitted[1]) > 499:
                 line_splitted[1] = line_splitted[1][:450]
 
             self.cursor.execute(SQL + " (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)", tuple(line_splitted))

--- a/biowardrobe_airflow_analysis/biowardrobe/download.py
+++ b/biowardrobe_airflow_analysis/biowardrobe/download.py
@@ -94,7 +94,7 @@ https_proxy="${{PROXY}}"
 #    'start_date': datetime.utcnow(),
 args = {
     'owner': 'airflow',
-    'start_date': datetime(1970, 1, 1),
+    'start_date': datetime(1970, 1, 1, 1, 1, 1, 1),
     'depends_on_past': False,
     'email': ['biowardrobe@biowardrobe.com'],
     'email_on_failure': False,
@@ -450,7 +450,7 @@ dag_t = DAG(
     dag_id='biowardrobe_download_trigger',
     default_args={
         'owner': 'airflow',
-        'start_date': datetime(1970, 1, 1),
+        'start_date': datetime(1970, 1, 1, 1, 1, 1, 1),
         'depends_on_past': False,
         'email': ['biowardrobe@biowardrobe.com'],
         'email_on_failure': False,

--- a/biowardrobe_airflow_analysis/biowardrobe/force_run.py
+++ b/biowardrobe_airflow_analysis/biowardrobe/force_run.py
@@ -175,7 +175,7 @@ dag = DAG(
     dag_id='biowardrobe-force-run',
     default_args={
         "owner": "airflow",
-        "start_date": datetime(1970, 1, 1),
+        "start_date": datetime(1970, 1, 1, 1, 1, 1, 1),
         'depends_on_past': False,
         'email': ['biowardrobe@biowardrobe.com'],
         'email_on_failure': False,


### PR DESCRIPTION
If iaintersect coudn't assign gene, the refseq_id
and gene_id are "NULL" (read it as None). When
trying to get len() from the None, we fail.
We don't want to exclude lines with "NULL", because
this is the islands from MACS2 and we don't wanna
loose them.

Fo Airflow 1.10.3 when setting start_date use `datetime` with all the parameters